### PR TITLE
Reference Links and starting dowload

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,6 +9,9 @@ This file lists all reference material that is of use during the development of 
 
 ## Microsoft documentation
 
+- [Overview of a Microsoft Extension](https://docs.microsoft.com/en-us/azure/devops/extend/overview?view=azure-devops)
+This provies an overview of developing custom extensions and service-hooks.
+
 - [Manifest Information](https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops)
 The manifest provides the extension integration points into Azure DevOps and the Marketplace.
 
@@ -21,6 +24,12 @@ The latest SDK to use for an extension as Azure DevOps Extension SDK is promoted
 - [UI Compontents](https://developer.microsoft.com/en-gb/azure-devops/components)
 The Formula Design System provides common UI widgets for Azure DevOps extensions as well as design recommendations.
 
+- [API Endpoints](https://docs.microsoft.com/en-us/previous-versions/azure/devops/integrate/previous-apis/overview)
+Public API that are available for Azure DevOps.
+
+- [Icon Names](https://uifabricicons.azurewebsites.net/)
+Icon names available when using the ***icons*** such as ```iconName``` attributes in various UI components.
+
 ## Sample code
 
 - [Azure DevOps Web Sample Extension](https://github.com/microsoft/azure-devops-extension-sample)
@@ -31,3 +40,6 @@ How to create a hot reloable plugin for different environments. This extension l
 
 - [Visual Studio Team Services (VSTS) Sample Extensions](https://github.com/microsoft/vsts-extension-samples)
 Repository of examples which are better used as an idea of how to approach problems then actual code references as this uses the VSS SDK.
+
+- [Azure DevOps Engineering Marketplace Extensions](https://github.com/microsoft/azure-devops-engineering-extensions)
+Another one, has an example of emailing and PR. However, this is more of a pipeline task sending emails, which doesn't meet our use case.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,16 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz",
+      "integrity": "sha512-x/XYVQ1h684pp1mJwOV4CyvqZXqbc8CMsMGUnAbuc82ZCdv1U63w5RSUzgDSXQHG5Rps/kiksH6g2D5BuaKyXg==",
+      "optional": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -68,6 +78,12 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
       "dev": true
+    },
+    "@types/raf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
+      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==",
+      "optional": true
     },
     "@types/react": {
       "version": "16.14.4",
@@ -711,8 +727,7 @@
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "available-typed-arrays": {
       "version": "1.0.2",
@@ -844,6 +859,12 @@
           }
         }
       }
+    },
+    "base64-arraybuffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "optional": true
     },
     "base64-inline-loader": {
       "version": "1.1.1",
@@ -1133,6 +1154,11 @@
         "pako": "~1.0.5"
       }
     },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
+    },
     "buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -1278,6 +1304,20 @@
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
           "dev": true
         }
+      }
+    },
+    "canvg": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.7.tgz",
+      "integrity": "sha512-4sq6iL5Q4VOXS3PL1BapiXIZItpxYyANVzsAKpTPS5oq4u3SKbGfUcbZh2gdLCQ3jWpG/y5wRkMlBBAJhXeiZA==",
+      "optional": true,
+      "requires": {
+        "@babel/runtime-corejs3": "^7.9.6",
+        "@types/raf": "^3.4.0",
+        "raf": "^3.4.1",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^5.0.5"
       }
     },
     "caseless": {
@@ -1730,6 +1770,12 @@
       "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
       "dev": true
     },
+    "core-js-pure": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.10.0.tgz",
+      "integrity": "sha512-CC582enhrFZStO4F8lGI7QL3SYx7/AIRc+IdSi3btrQGrVsTawo5K/crmKbRrQ+MOMhNX4v+PATn0k2NN6wI7A==",
+      "optional": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1830,6 +1876,15 @@
         "public-encrypt": "^4.0.0",
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
+      }
+    },
+    "css-line-break": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-1.1.1.tgz",
+      "integrity": "sha512-1feNVaM4Fyzdj4mKPIQNL2n70MmuYzAXZ1aytlROFX1JsOo070OsugwGjj7nl6jnDJWHDM8zRZswkmeYVWZJQA==",
+      "optional": true,
+      "requires": {
+        "base64-arraybuffer": "^0.2.0"
       }
     },
     "css-loader": {
@@ -2215,6 +2270,12 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
+    },
+    "dompurify": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.7.tgz",
+      "integrity": "sha512-jdtDffdGNY+C76jvodNTu9jt5yYj59vuTUyx+wXdzcSwAGTYZDAQkQ7Iwx9zcGrA4ixC1syU4H3RZROqRxokxg==",
+      "optional": true
     },
     "duplexify": {
       "version": "3.7.1",
@@ -2978,6 +3039,11 @@
       "requires": {
         "websocket-driver": ">=0.5.1"
       }
+    },
+    "fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -3822,6 +3888,15 @@
       "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
       "dev": true
     },
+    "html2canvas": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.0.0-rc.7.tgz",
+      "integrity": "sha512-yvPNZGejB2KOyKleZspjK/NruXVQuowu8NnV2HYG7gW7ytzl+umffbtUI62v2dCHQLDdsK6HIDtyJZ0W3neerA==",
+      "optional": true,
+      "requires": {
+        "css-line-break": "1.1.1"
+      }
+    },
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -4623,6 +4698,28 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jspdf": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.3.1.tgz",
+      "integrity": "sha512-1vp0USP1mQi1h7NKpwxjFgQkJ5ncZvtH858aLpycUc/M+r/RpWJT8PixAU7Cw/3fPd4fpC8eB/Bj42LnsR21YQ==",
+      "requires": {
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "fflate": "^0.4.8",
+        "html2canvas": "^1.0.0-rc.5"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
+          "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==",
+          "optional": true
+        }
       }
     },
     "jsprim": {
@@ -5822,8 +5919,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -6168,6 +6264,15 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true
     },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "optional": true,
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6343,6 +6448,12 @@
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "optional": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -6532,6 +6643,12 @@
       "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
       "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
       "dev": true
+    },
+    "rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha1-1lBezbMEplldom+ktDMHMGd1lF0=",
+      "optional": true
     },
     "rimraf": {
       "version": "2.7.1",
@@ -7253,6 +7370,12 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
+    "stackblur-canvas": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz",
+      "integrity": "sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==",
+      "optional": true
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -7488,6 +7611,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "svg-pathdata": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-5.0.5.tgz",
+      "integrity": "sha512-TAAvLNSE3fEhyl/Da19JWfMAdhSXTYeviXsLSoDT1UM76ADj5ndwAPX1FKQEgB/gFMPavOy6tOqfalXKUiXrow==",
+      "optional": true
     },
     "table": {
       "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "azure-devops-extension-sdk": "^2.0.11",
     "azure-devops-ui": "^1.160.4",
     "date-fns": "^2.19.0",
+    "jspdf": "^2.3.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0"
   },

--- a/src/Common/Project.service.ts
+++ b/src/Common/Project.service.ts
@@ -44,6 +44,11 @@ export class ProjectService {
   static BASE_URL: string;
 
   /**
+   * Work item prepend.
+   */
+  private static prependWitEditUrl = "/_workitems/edit/"
+
+  /**
    * Display a date without time.
    *
    * @param date date
@@ -61,6 +66,16 @@ export class ProjectService {
     } else {
       return formatDate(date, "yyyyMMdd");
     }
+  }
+
+  /**
+   * Generate the URL to edit a work item.
+   *
+   * @param id the id of the work item.
+   */
+  public static async generateWitEditUrl(id:string|number):Promise<string> {
+    const baseUrl = await this.getBaseUrl();
+    return baseUrl + this.prependWitEditUrl + id;
   }
 
   /**

--- a/src/Common/Project.service.ts
+++ b/src/Common/Project.service.ts
@@ -46,7 +46,7 @@ export class ProjectService {
   /**
    * Work item prepend.
    */
-  private static prependWitEditUrl = "/_workitems/edit/"
+  private static prependWitEditUrl = "/_workitems/edit/";
 
   /**
    * Display a date without time.
@@ -73,7 +73,7 @@ export class ProjectService {
    *
    * @param id the id of the work item.
    */
-  public static async generateWitEditUrl(id:string|number):Promise<string> {
+  public static async generateWitEditUrl(id: string | number): Promise<string> {
     const baseUrl = await this.getBaseUrl();
     return baseUrl + this.prependWitEditUrl + id;
   }

--- a/src/Print/PrintPDF.tsx
+++ b/src/Print/PrintPDF.tsx
@@ -1,0 +1,23 @@
+import { jsPDF } from "jspdf";
+
+/**
+ * Event handler to print the page. As each page inside this extension is wrapped by an
+ * iFRAME, printing the body won't print the other UI elements in Azure Boards.
+ * For example, the navigation bar and left mmenu as those are also in another IFRAME.
+ */
+export class PrintPDF {
+    public static eventHandlderPrint():void {
+        const pdf = new jsPDF({
+            orientation: "portrait",
+            unit: "in",
+            format: [8.5, 11]
+          });
+
+          pdf.html(document.body).then(() =>
+          {
+              console.log("printing...")
+            pdf.save();
+          });
+
+    }
+}

--- a/src/Print/PrintPDF.tsx
+++ b/src/Print/PrintPDF.tsx
@@ -1,4 +1,5 @@
-import { jsPDF } from "jspdf";
+import { jsPDF, HTMLWorker } from "jspdf";
+import html2canvas from "html2canvas";
 
 /**
  * Event handler to print the page. As each page inside this extension is wrapped by an
@@ -6,18 +7,24 @@ import { jsPDF } from "jspdf";
  * For example, the navigation bar and left mmenu as those are also in another IFRAME.
  */
 export class PrintPDF {
-    public static eventHandlderPrint():void {
-        const pdf = new jsPDF({
-            orientation: "portrait",
-            unit: "in",
-            format: [8.5, 11]
-          });
+  public static async eventHandlderPrint(): Promise<void> {
+    (window as any).html2canvas = html2canvas;
 
-          pdf.html(document.body).then(() =>
-          {
-              console.log("printing...")
-            pdf.save();
-          });
+    var pdf = new jsPDF("p", "pt", "letter");
+    // const pdf = new jsPDF({
+    //     orientation: "portrait",
+    //     unit: "in",
+    //     format: [8.5, 11]
+    //   });
 
+    var content = document.getElementById("root");
+
+    if (content) {
+      pdf.html(content, {
+        callback: function(pdf) {
+          pdf.save("cv-a4.pdf");
+        }
+      });
     }
+  }
 }

--- a/src/StatusReportHub/StatusEntry.entity.ts
+++ b/src/StatusReportHub/StatusEntry.entity.ts
@@ -4,6 +4,7 @@ import { WorkItem } from "azure-devops-extension-api/WorkItemTracking";
 // Project Level
 import { StatusReportConfig } from "./StatusReport.config";
 import { WorkItemBaseEntity } from "../Common/WorkItemBase.entity";
+import { ImpedimentsEntity } from "./Impediments.entity";
 
 /**
  * The status entry for the status report page.
@@ -32,7 +33,7 @@ export class StatusEntryEntity extends WorkItemBaseEntity {
   /**
    * The key issues.
    */
-  keyIssues: string[] = [];
+  keyIssues: ImpedimentsEntity[] = [];
 
   /**
    * The target date
@@ -51,9 +52,9 @@ export class StatusEntryEntity extends WorkItemBaseEntity {
   /**
    * Add the impediment to the list.
    *
-   * @param impedimentTitle the title of the impediment.
+   * @param impediment the impediment.
    */
-  public addImpediment(impedimentTitle: string) {
-    this.keyIssues.push(impedimentTitle);
+  public addImpediment(impediment: ImpedimentsEntity) {
+    this.keyIssues.push(impediment);
   }
 }

--- a/src/StatusReportHub/StatusReport.service.ts
+++ b/src/StatusReportHub/StatusReport.service.ts
@@ -305,23 +305,11 @@ export class StatusReportService {
         // Go down a level as impediment is there.
         if (node.children[0].data) {
           // We have an impediment mapped to a project.
-          relatedNode.data.addImpediment(node.children[0].data.title);
+          relatedNode.data.addImpediment(node.children[0].data);
+          console.log(node.children[0].data);
         }
       }
     }
-  }
-
-  /**
-   * Get the latest status report entity definition.
-   *
-   * @returns the latest status report entity definition.
-   */
-  static getLatestStatusReport(): StatusReportEntity {
-    return {
-      id: undefined,
-      name: "Latest",
-      asOf: undefined
-    };
   }
 
   /**

--- a/src/StatusReportHub/StatusReport.service.ts
+++ b/src/StatusReportHub/StatusReport.service.ts
@@ -306,7 +306,6 @@ export class StatusReportService {
         if (node.children[0].data) {
           // We have an impediment mapped to a project.
           relatedNode.data.addImpediment(node.children[0].data);
-          console.log(node.children[0].data);
         }
       }
     }

--- a/src/StatusReportHub/StatusReportCommandMenu.ui.ts
+++ b/src/StatusReportHub/StatusReportCommandMenu.ui.ts
@@ -23,7 +23,9 @@ export class StatusReportCommandMenu {
     important: true,
     text: "Download",
     disabled: true,
-    onActivate: PrintPDF.eventHandlderPrint
+    onActivate: function() {
+      PrintPDF.eventHandlderPrint();
+    }
   };
 
   /**
@@ -52,19 +54,6 @@ export class StatusReportCommandMenu {
   };
 
   /**
-   * The approve button.
-   */
-  private approveButton: IHeaderCommandBarItem = {
-    iconProps: {
-      iconName: "CheckMark"
-    },
-    id: "itrp-pm-status-hub-header-approve",
-    important: false,
-    text: "Approve item",
-    disabled: true
-  };
-
-  /**
    * Delete button.
    */
   private deleteButton: IHeaderCommandBarItem = {
@@ -76,27 +65,12 @@ export class StatusReportCommandMenu {
     disabled: true
   };
 
-  /**
-   * Bulk Delete button.
-   */
-  private bulkDeleteButton: IHeaderCommandBarItem = {
-    iconProps: {
-      iconName: "Delete"
-    },
-    id: "itrp-pm-status-hub-header-bulk-delete",
-    text: "Bulk Delete",
-    disabled: true
-  };
-
   /** Used to trigger update. */
   buttons: ObservableValue<IHeaderCommandBarItem[]> = new ObservableValue([
     this.downloadButton,
     this.refreshButton,
     this.saveButton,
-//    this.approveButton,
-//    { id: "separator", itemType: MenuItemType.Divider },
-    this.deleteButton,
-//    this.bulkDeleteButton
+    this.deleteButton
   ]);
 
   /**
@@ -105,7 +79,6 @@ export class StatusReportCommandMenu {
    * @param currentPage the current page data
    */
   public updateButtonStatuses(currentPage: IStatusReportHubState): void {
-
     /*
      * Record can only be saved if not approved state. Presently, only
      * the latest copy is not approved state.
@@ -127,7 +100,7 @@ export class StatusReportCommandMenu {
     this.saveButton.disabled = !saveableRecord;
     this.deleteButton.disabled = !storedRecord;
     this.refreshButton.disabled = !saveableRecord;
-    this.downloadButton.disabled = !storedRecord;
+    this.downloadButton.disabled = false;
 
     // Notify the subscribers.
     this.buttons.notify(this.buttons.value, "updateButtonStatus");

--- a/src/StatusReportHub/StatusReportCommandMenu.ui.ts
+++ b/src/StatusReportHub/StatusReportCommandMenu.ui.ts
@@ -27,14 +27,14 @@ export class StatusReportCommandMenu {
   };
 
   /**
-   * Share button.
+   * Refresh button.
    */
-  private shareButton: IHeaderCommandBarItem = {
+  private refreshButton: IHeaderCommandBarItem = {
     iconProps: {
-      iconName: "Share"
+      iconName: "Refresh"
     },
-    id: "itrp-pm-status-hub-header-share",
-    text: "Share",
+    id: "itrp-pm-status-hub-header-refresh",
+    text: "Refresh",
     disabled: true
   };
 
@@ -91,12 +91,12 @@ export class StatusReportCommandMenu {
   /** Used to trigger update. */
   buttons: ObservableValue<IHeaderCommandBarItem[]> = new ObservableValue([
     this.downloadButton,
-    this.shareButton,
+    this.refreshButton,
     this.saveButton,
-    this.approveButton,
-    { id: "separator", itemType: MenuItemType.Divider },
+//    this.approveButton,
+//    { id: "separator", itemType: MenuItemType.Divider },
     this.deleteButton,
-    this.bulkDeleteButton
+//    this.bulkDeleteButton
   ]);
 
   /**
@@ -126,7 +126,7 @@ export class StatusReportCommandMenu {
 
     this.saveButton.disabled = !saveableRecord;
     this.deleteButton.disabled = !storedRecord;
-    this.shareButton.disabled = !storedRecord;
+    this.refreshButton.disabled = !saveableRecord;
     this.downloadButton.disabled = !storedRecord;
 
     // Notify the subscribers.
@@ -162,17 +162,17 @@ export class StatusReportCommandMenu {
   }
 
   /**
-   * Attach the event to a share button click.
+   * Attach the event to a refresh button click.
    *
    * @param event event to fire
    */
-  public attachOnShareActivate(
+  public attachOnRefreshActivate(
     event: (
       menuItem: IMenuItem,
       event?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
     ) => boolean | void
   ): void {
-    this.shareButton.onActivate = event;
+    this.refreshButton.onActivate = event;
   }
 
   /**
@@ -203,6 +203,6 @@ export class StatusReportCommandMenu {
     this.attachOnDeleteActivate(event);
     this.attachOnDownloadActivate(event);
     this.attachOnSaveActivate(event);
-    this.attachOnShareActivate(event);
+    this.attachOnRefreshActivate(event);
   }
 }

--- a/src/StatusReportHub/StatusReportHub.scss
+++ b/src/StatusReportHub/StatusReportHub.scss
@@ -76,3 +76,4 @@ table.status-report-tables {
 div.activityTitle {
     font-weight: bold;
 }
+

--- a/src/StatusReportHub/StatusReportHub.tsx
+++ b/src/StatusReportHub/StatusReportHub.tsx
@@ -108,6 +108,12 @@ class StatusReportHub extends React.Component<{}, IStatusReportHubState> {
     this.commandButtons.attachOnDeleteActivate(() => {
       self.eventHandlerDeleteButton();
     });
+
+    // Delete event
+    this.commandButtons.attachOnRefreshActivate(() => {
+      self.showInProgress();
+      self.loadRecord();
+    });
   }
 
   /**

--- a/src/StatusReportHub/StatusReportHub.tsx
+++ b/src/StatusReportHub/StatusReportHub.tsx
@@ -20,10 +20,7 @@ import { IListBoxItem, ListBoxItemType } from "azure-devops-ui/ListBox";
 import { Observer } from "azure-devops-ui/Observer";
 import { Page } from "azure-devops-ui/Page";
 import { Pill } from "azure-devops-ui/Pill";
-import {
-  Spinner,
-  SpinnerSize
-} from "azure-devops-ui/Spinner";
+import { Spinner, SpinnerSize } from "azure-devops-ui/Spinner";
 import {
   IStatusProps,
   Status,
@@ -79,7 +76,7 @@ class StatusReportHub extends React.Component<{}, IStatusReportHubState> {
   /**
    * Work item URL prefix
    */
-  private witItemUrlPrefix:string = "";
+  private witItemUrlPrefix: string = "";
 
   constructor(props: {}) {
     super(props);
@@ -181,7 +178,7 @@ class StatusReportHub extends React.Component<{}, IStatusReportHubState> {
     }
   }
 
-  private async getEditUrl():Promise<void> {
+  private async getEditUrl(): Promise<void> {
     this.witItemUrlPrefix = await ProjectService.generateWitEditUrl("");
   }
 
@@ -317,7 +314,10 @@ class StatusReportHub extends React.Component<{}, IStatusReportHubState> {
               excludeFocusZone={true}
               excludeTabStop={true}
             >
-              <Link href={this.witItemUrlPrefix + rowData.id} target="_blank">#{rowData.id}</Link>: {rowData.title}
+              <Link href={this.witItemUrlPrefix + rowData.id} target="_blank">
+                #{rowData.id}
+              </Link>
+              : {rowData.title}
             </Pill>
             <p>
               <b>Objective</b>
@@ -332,10 +332,18 @@ class StatusReportHub extends React.Component<{}, IStatusReportHubState> {
             </p>
             {rowData.keyIssues.length > 0 && (
               <ul>
-                {rowData.keyIssues.map((value) => {
-                  return <li key={value.id}>
-                    <Link href={this.witItemUrlPrefix + value.id} target="_blank">#{value.id}</Link>: {value.title}
-                  </li>;
+                {rowData.keyIssues.map(value => {
+                  return (
+                    <li key={value.id}>
+                      <Link
+                        href={this.witItemUrlPrefix + value.id}
+                        target="_blank"
+                      >
+                        #{value.id}
+                      </Link>
+                      : {value.title}
+                    </li>
+                  );
                 })}
               </ul>
             )}
@@ -356,7 +364,7 @@ class StatusReportHub extends React.Component<{}, IStatusReportHubState> {
         <tr className="status-report-grouped-header-row">
           <th colSpan={3}>{groupTitle}</th>
         </tr>
-        {this.state.statusReport?.get(groupTitle)?.map((value) => {
+        {this.state.statusReport?.get(groupTitle)?.map(value => {
           return this.writeStatusRow(value);
         })}
       </tbody>

--- a/src/StatusReportHub/StatusReportHub.tsx
+++ b/src/StatusReportHub/StatusReportHub.tsx
@@ -15,6 +15,7 @@ import {
   TitleSize
 } from "azure-devops-ui/Header";
 import { HeaderCommandBar } from "azure-devops-ui/HeaderCommandBar";
+import { Link } from "azure-devops-ui/Link";
 import { IListBoxItem, ListBoxItemType } from "azure-devops-ui/ListBox";
 import { Observer } from "azure-devops-ui/Observer";
 import { Page } from "azure-devops-ui/Page";
@@ -316,7 +317,7 @@ class StatusReportHub extends React.Component<{}, IStatusReportHubState> {
               excludeFocusZone={true}
               excludeTabStop={true}
             >
-              <a href={this.witItemUrlPrefix + rowData.id} target="_blank">#{rowData.id}</a>: {rowData.title}
+              <Link href={this.witItemUrlPrefix + rowData.id} target="_blank">#{rowData.id}</Link>: {rowData.title}
             </Pill>
             <p>
               <b>Objective</b>
@@ -333,7 +334,7 @@ class StatusReportHub extends React.Component<{}, IStatusReportHubState> {
               <ul>
                 {rowData.keyIssues.map((value) => {
                   return <li key={value.id}>
-                    <a href={this.witItemUrlPrefix + value.id} target="_blank">#{value.id}</a>: {value.title}
+                    <Link href={this.witItemUrlPrefix + value.id} target="_blank">#{value.id}</Link>: {value.title}
                   </li>;
                 })}
               </ul>
@@ -508,9 +509,9 @@ class StatusReportHub extends React.Component<{}, IStatusReportHubState> {
                           <div>
                             <p>
                               Please ensure the{" "}
-                              <a href={this.state.queryUrl} target={"_top"}>
+                              <Link href={this.state.queryUrl} target={"_top"}>
                                 {this.state.currentSourceQuery?.name}
-                              </a>{" "}
+                              </Link>{" "}
                               query actually produces a result.
                             </p>
                           </div>


### PR DESCRIPTION
- Remove share button as unable to send emails. The "mailto" option was explored, however due to different client implementations, unable to send beyond a plain text email. 
    - That means potentially no formatted pretty emails and URLs not clickable. 
    - To implement this correctly, a web API call needs to be done against a web hook somewhere that will not leak the secrets. AKA, that API call cannot happen inside the extension as it is client side JS.
-  Add links to impediment and epic inside the status report
- Added download button, however working out options as printing canvas doesn't always work
